### PR TITLE
API rework (WIP)

### DIFF
--- a/src/GenerateRenderRuntimeInterface.php
+++ b/src/GenerateRenderRuntimeInterface.php
@@ -5,26 +5,27 @@ namespace ReactJS;
 /**
  * @package ReactJS
  */
-interface RenderInterface
+interface GenerateRenderRuntimeInterface
 {
     /**
      * @param $componentPath
      * @param array|void $props
+     * @param string $renderedMountableComponentMarkup
      * @return string
      */
-    public function renderMountedComponent($componentPath, $props = null);
+    public function mountedComponentMarkup($componentPath, $props = null, $renderedMountableComponentMarkup = '');
 
     /**
      * @param $componentPath
      * @param array|void $props
      * @return string
      */
-    public function renderMountableComponent($componentPath, $props = null);
-    
+    public function mountableComponentJS($componentPath, $props = null);
+
     /**
      * @param $componentPath
      * @param array|void $props
      * @return string
      */
-    public function renderStaticComponent($componentPath, $props = null);
+    public function staticComponentJS($componentPath, $props = null);
 }

--- a/src/HTTPServerRenderer.php
+++ b/src/HTTPServerRenderer.php
@@ -41,6 +41,7 @@ class HTTPServerRenderer implements RenderInterface
         $this->port = (int) $port;
         $this->path = (string) $path;
         $this->ssl = (bool) $ssl;
+        $this->$generate = new SyncRequireGenerator();
     }
 
     /**
@@ -48,9 +49,13 @@ class HTTPServerRenderer implements RenderInterface
      * @param array|void $props
      * @return string
      */
-    public function renderComponentToString($componentPath, $props = null)
+    public function renderMountedComponent($componentPath, $props = null)
     {
-        return $this->render(__FUNCTION__, $componentPath, $props);
+        return $this->$generate->mountedComponentMarkup(
+            $componentPath,
+            $props,
+            $this->renderMountableComponent($componentPath, $props)
+        );
     }
 
     /**
@@ -58,18 +63,28 @@ class HTTPServerRenderer implements RenderInterface
      * @param array|void $props
      * @return string
      */
-    public function renderComponentToStaticMarkup($componentPath, $props = null)
+    public function renderMountableComponent($componentPath, $props = null)
     {
-        return $this->render(__FUNCTION__, $componentPath, $props);
+        return $this->render('mountable', $componentPath, $props);
     }
 
     /**
-     * @param $reactFunction
+     * @param $componentPath
+     * @param array|void $props
+     * @return string
+     */
+    public function renderStaticComponent($componentPath, $props = null)
+    {
+        return $this->render('static', $componentPath, $props);
+    }
+
+    /**
+     * @param $reactRenderType
      * @param $componentPath
      * @param null $props
      * @return string
      */
-    private function render($reactFunction, $componentPath, $props = null)
+    private function render($reactRenderType, $componentPath, $props = null)
     {
         $client = new Client();
     
@@ -83,7 +98,7 @@ class HTTPServerRenderer implements RenderInterface
             ),
             [
                 "body" => [
-                    "reactFunction" => $reactFunction,
+                    "renderType" => $reactRenderType,
                     "componentPath" => $componentPath,
                     "props" => json_encode($props)
                 ]

--- a/src/NullRenderer.php
+++ b/src/NullRenderer.php
@@ -9,24 +9,45 @@ use RuntimeException;
  */
 class NullRenderer implements RenderInterface
 {
+    public function __construct()
+    {
+        $this->$generate = new SyncRequireGenerator();
+    }
+
     /**
      * @param $componentPath
      * @param array|void $props
      * @return string
      */
-    public function renderComponentToString($componentPath, $props = null)
+    public function renderMountedComponent($componentPath, $props = null)
+    {
+        return $this->$generate->mountedComponentMarkup(
+            $componentPath,
+            $props,
+            $this->renderMountableComponent($componentPath, $props)
+        );
+    }
+
+    /**
+     * @param $componentPath
+     * @param array|void $props
+     * @return string
+     */
+    public function renderMountableComponent($componentPath, $props = null)
     {
         return '';
     }
 
     /**
      * @param $componentPath
-     * @param null $props
-     * @return string|void
+     * @param array|void $props
+     * @return string
      * @throws \RuntimeException
      */
-    public function renderComponentToStaticMarkup($componentPath, $props = null)
+    public function renderStaticComponent($componentPath, $props = null)
     {
-        throw new RuntimeException("renderComponentToStaticMarkup not supported for null renderer");
+        throw new RuntimeException("renderStaticComponent not supported for null renderer");
     }
+
+
 }

--- a/src/SyncRequireGenerator.php
+++ b/src/SyncRequireGenerator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ReactJS;
+
+
+class SyncRequireGenerator implements GenerateRenderRuntimeInterface
+{
+    /**
+     * @param $componentPath
+     * @param array|void $props
+     * @param string $renderedMountableComponentMarkup
+     * @return string
+     */
+    public function mountedComponentMarkup($componentPath, $props = null, $renderedMountableComponentMarkup = '')
+    {
+        $container_id = uniqid();
+
+        $container_markup = sprintf(
+            "<div id=\"%s\">%s</div>",
+            $container_id,
+            $renderedMountableComponentMarkup
+        );
+
+        $script_markup = sprintf(
+            "<script>require('react').renderComponent(require(%s)(%s),document.getElementById(%s))</script>",
+            json_encode($componentPath),
+            json_encode($props),
+            json_encode($container_id)
+        );
+
+        return $container_markup . $script_markup;
+    }
+
+    /**
+     * @param $componentPath
+     * @param array|void $props
+     * @return string
+     */
+    public function mountableComponentJS($componentPath, $props = null)
+    {
+        $markup = sprintf(
+            "require('react').renderComponentToString(require(%s)(%s));",
+            json_encode($componentPath),
+            json_encode($props)
+        );
+
+        return $markup;
+    }
+
+    /**
+     * @param $componentPath
+     * @param array|void $props
+     * @return string
+     */
+    public function staticComponentJS($componentPath, $props = null)
+    {
+        $markup = sprintf(
+            "require('react').renderComponentToStaticMarkup(require(%s)(%s));",
+            json_encode($componentPath),
+            json_encode($props)
+        );
+
+        return $markup;
+    }
+} 


### PR DESCRIPTION
A possible API to make things more flexible
- Abstracted `RenderInterface` methods from the react JS render\* naming.
- Supports returning markup with JS initialisation code via `renderMountedComponent`.
- `GenerateRenderRuntimeInterface` allows creating custom runtimes for your code specific to your JS environment, I have implemented an example generator for commonJS/bundled AMD runtimes.

Im pretty unsure about all the names of things here, but do feel they are looking in better direction.

Note: this code is not working and just has been changed enough to reflect a possible API
